### PR TITLE
增加Redis配置、增加Swagger界面身份验证与浏览器端持久化授权

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -78,6 +78,7 @@ def create_app() -> FastAPI:
         description=settings.APP_DESCRIPTION,
         version=settings.VERSION,
         openapi_url="/openapi.json",
+        swagger_ui_parameters={"persistAuthorization": True},
         middleware=make_middlewares(),
         lifespan=lifespan,
         redirect_slashes=False,

--- a/app/cli.py
+++ b/app/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import platform
 from collections.abc import Awaitable, Callable, Sequence
 
 from granian import Granian
@@ -28,14 +29,33 @@ async def run_with_database_context(operation: AsyncOperation) -> None:
 
 
 def serve() -> None:
+    server_options = build_server_options()
     Granian(
         "app.asgi:app",
         interface="asgi",
         address=settings.HOST,
         port=settings.PORT,
         reload=settings.server_reload_enabled,
+        **server_options,
         **RELOAD_CONFIG,
     ).serve()
+
+
+def build_server_options() -> dict[str, int]:
+    current_platform = platform.system().lower()
+
+    if current_platform == "windows":
+        return {"workers": 1}
+
+    if current_platform == "linux":
+        return {
+            "workers": 8,
+            "runtime_threads": 10,
+            "runtime_blocking_threads": 4,
+            "blocking_threads": 1,
+        }
+
+    return {}
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/app/core/dependency.py
+++ b/app/core/dependency.py
@@ -2,7 +2,8 @@ import time
 from typing import Annotated, Optional, Set
 
 import jwt
-from fastapi import Depends, Header, Request, Query
+from fastapi import Depends, Query, Request, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from tortoise.expressions import F
 
 from app.core.exceptions import AuthenticationError, AuthorizationError, RateLimitError
@@ -16,6 +17,7 @@ class AuthControl:
     """Authentication controller."""
 
     # Load the IP allowlist from the current settings.
+    _bearer_scheme = HTTPBearer(auto_error=False)
     _ip_whitelist: Set[str] = set(settings.ip_whitelist)
     _trusted_proxy_ips: Set[str] = set(settings.trusted_proxy_ips)
     _trust_proxy_headers: bool = settings.TRUST_PROXY_HEADERS
@@ -140,11 +142,12 @@ class AuthControl:
 
     @classmethod
     async def is_authed(
-        cls, request: Request, authorization: str = Header(..., description="Bearer access token")
+        cls,
+        request: Request,
+        _credentials: HTTPAuthorizationCredentials | None = Security(_bearer_scheme),
     ) -> User:
         """
         Main authentication entrypoint.
-        :param authorization: Bearer token.
         :param request: Request object.
         :return: Authenticated user.
         """
@@ -153,6 +156,7 @@ class AuthControl:
             if not cls.check_ip_whitelist(client_ip):
                 raise AuthorizationError("IP地址未授权访问")
 
+            authorization = request.headers.get("authorization", "")
             token = cls.extract_bearer_token(authorization)
             payload = cls._validate_access_token(token)
             user_id = int(payload["user_id"])

--- a/app/settings/config.py
+++ b/app/settings/config.py
@@ -111,6 +111,14 @@ class Settings(BaseSettings):
     DB_PASSWORD: str = Field(default="", description="数据库密码")
     DB_DATABASE: str = Field(default="fastapi_admin", description="数据库名称")
 
+    # Redis 配置
+    REDIS_ENABLED: bool = Field(default=False, description="是否启用 Redis")
+    REDIS_HOST: str = Field(default="127.0.0.1", description="Redis 主机")
+    REDIS_PORT: int = Field(default=63790, description="Redis 端口")
+    REDIS_DB: int = Field(default=5, description="Redis 数据库索引")
+    REDIS_PASSWORD: str = Field(default="infini_rag_flow_ZSRZ1!$", description="Redis 密码")
+    REDIS_PREFIX: str = Field(default="financial:", description="Redis 前缀")
+
     # Date and time formatting.
     DATETIME_FORMAT: str = Field(default="%Y-%m-%d %H:%M:%S", description="日期时间格式")
 

--- a/app/settings/config.py
+++ b/app/settings/config.py
@@ -116,8 +116,8 @@ class Settings(BaseSettings):
     REDIS_HOST: str = Field(default="127.0.0.1", description="Redis 主机")
     REDIS_PORT: int = Field(default=63790, description="Redis 端口")
     REDIS_DB: int = Field(default=5, description="Redis 数据库索引")
-    REDIS_PASSWORD: str = Field(default="infini_rag_flow_ZSRZ1!$", description="Redis 密码")
-    REDIS_PREFIX: str = Field(default="financial:", description="Redis 前缀")
+    REDIS_PASSWORD: str = Field(default="123456", description="Redis 密码")
+    REDIS_PREFIX: str = Field(default="react-fastapi:", description="Redis 前缀")
 
     # Date and time formatting.
     DATETIME_FORMAT: str = Field(default="%Y-%m-%d %H:%M:%S", description="日期时间格式")


### PR DESCRIPTION
1、 .env.example 有Redis的配置信息，但是 config.py 是却没有；
2、 Swagger界面，API调试时认证不方便，页面一刷新认证信息会丢失；现在认证后会把身份验证持久化到浏览器端，页面刷新仍然可用，一次认证多次使用，直到Token过期为止。